### PR TITLE
More responsive grid... with flex

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,10 +8,10 @@
 	<meta property="og:title" content="{%if page.title%}{{page.title}} | {%endif%}Debuggy"/>
 	<meta property="og:description" content="{{page.description}}"/>
 	{% if page.style %}
-	<link rel="stylesheet" href="/assets/css/{{page.style}}.css"/>
+	<link rel="stylesheet" href="assets/css/{{page.style}}.css"/>
 	{% endif %}
 	{% for style in page.styles %}
-	<link rel="stylesheet" href="/assets/css/{{style}}.css"/>
+	<link rel="stylesheet" href="assets/css/{{style}}.css"/>
 	{% endfor %}
 </head>
 <body>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -27,7 +27,7 @@ a {
 
 main {
 	min-height: 100%;
-	max-width: 140ch;
+	max-width: 90em;
 	margin-inline: auto;
 	text-align: center;
 }
@@ -50,7 +50,7 @@ ul, ol {
 }
 
 .profiles {
-	
+
 	h1 {
 		margin: 0;
 		font-size: 28px;
@@ -88,7 +88,7 @@ ul, ol {
 			height: 30px;
 		}
 	}
-	
+
 	.role {
 		font-size: 18px;
 	}
@@ -105,11 +105,13 @@ ul, ol {
 }
 
 .profiles.dev-team {
-	display: grid;
-	row-gap: 73px;
-	grid-template-columns: 1fr 1fr 1fr;
-	grid-template-rows: 1fr 1fr;
-	place-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	flex-basis: 250px;
+	justify-content: center;
+	align-content: top;
+	flex-shrink: 0;
+	flex-grow: 1;
 
 	a {
 		color: black;
@@ -122,6 +124,8 @@ ul, ol {
 	.profile-card {
 		background-color: var(--debuggy-team);
 		border: 3px solid var(--debuggy-team-border);
+
+		margin: 20px 40px 20px 40px;
 	}
 
 	.profile-picture {


### PR DESCRIPTION
## Gets rid of the unnecessary absolute paths on scss files from assets

This helps me prototype much faster, using jekyll as a static site generator. Your mileage may vary.

## Switches dev team layout from grid to flex

The grid part of the layout will now work flawlessly on devices right down to about 250 "pixels" wide, and it just needs some minor touchups to the top navbar's layout styles now.

As a side effect, we got a bottom margin, too! Woohoo!